### PR TITLE
upgrade clojure and tools.cli

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,8 @@
   :description "Command Line Tool l99"
   :licence "FIX ME Licence"
   :url "http://www.example.com/FIXME"
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/tools.cli "0.4.2"]]
+  :dependencies [[org.clojure/clojure "1.11.2"]
+                 [org.clojure/tools.cli "1.1.230"]]
   :aot :all
   :main l99.core)
 


### PR DESCRIPTION
lein ancient を行ったところ、用いているClojure本体とtools-cliライブラリが古かったので更新した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Clojureとtools.cliの依存関係のバージョンが更新されました。Clojureは`1.10.1`から`1.11.2`へ、tools.cliは`0.4.2`から`1.1.230`へ変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->