### PR TITLE
seq?だとvectorがfalseになるので、coll?へ変更した

### DIFF
--- a/src/l99/list.clj
+++ b/src/l99/list.clj
@@ -52,7 +52,7 @@
 (defn l99-flatten-list [lst]
   "P07"
   ;; (flatten lst))
-  (if (seq? lst)
+  (if (coll? lst)
     (if-not (empty? lst)
       (concat (l99-flatten-list (first lst))
               (l99-flatten-list (rest  lst))))


### PR DESCRIPTION
flatten処理にて、リストっぽいものの判定に seq?を使っていたが、vectorはseq?でfalseになるのて、coll?に修正した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- リストを再帰的にフラット化する前に、入力がシーケンスかどうかをチェックするのではなく、コレクションかどうかをチェックするように変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->